### PR TITLE
Make compatible with Wagtail 2.0 and Django 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wagtail Simple Gallery
 Is an extension for Torchbox's [Wagtail CMS](https://github.com/torchbox/wagtail) for creating a simple image gallery either by creating a page using the template or a templatetag.
 
-Current version works with Wagtail 1.10.x - 1.13.x.
+Current version works with Wagtail 2.0.x & Django 2.0.x.
 
 
 ## Getting started
@@ -56,4 +56,4 @@ Or if **simple_gallery_index.html** is good enough for your use, then you can ju
 
 
 ## Admin Interface
-The admin view for images is customized so it can show more images at once. By default there are 20 images on one page, but you can have 32 by adding `url(r'', include('wagtail_simple_gallery.urls')),` in your urls.py above the `url(r'^admin/', include(wagtailadmin_urls)),` line. This requires wagtail version >= 1.6.3.
+The admin view for images is customized so it can show more images at once. By default there are 20 images on one page, but you can have 32 by adding `path('', include('wagtail_simple_gallery.urls')),` in your urls.py above the `re_path(r'^admin/', include(wagtailadmin_urls)),` line. This requires wagtail version >= 1.6.3.

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,15 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'wagtail>=1.10,<2.0',
+        'django>=2.0',
+        'wagtail>=2.0,<3.0',
     ],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/wagtail_simple_gallery/__init__.py
+++ b/wagtail_simple_gallery/__init__.py
@@ -1,2 +1,2 @@
 default_app_config = 'wagtail_simple_gallery.apps.WagtailSimpleGalleryConfig'
-__version__ = '0.5.1'
+__version__ = '0.6.0'

--- a/wagtail_simple_gallery/apps.py
+++ b/wagtail_simple_gallery/apps.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.apps import AppConfig
 
 

--- a/wagtail_simple_gallery/migrations/0001_initial.py
+++ b/wagtail_simple_gallery/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.wagtailcore.fields
+import wagtail.core.fields
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
                 ('intro_title', models.CharField(blank=True, help_text='Optional H1 title for the gallery page.', max_length=250)),
-                ('intro_text', wagtail.wagtailcore.fields.RichTextField(blank=True, help_text='Optional text to go with the intro text.')),
+                ('intro_text', wagtail.core.fields.RichTextField(blank=True, help_text='Optional text to go with the intro text.')),
                 ('images_per_page', models.IntegerField(default=8, help_text='How many images there should be on one page.')),
                 ('use_lightbox', models.BooleanField(default=True, help_text='Use lightbox to view larger images when clicking the thumbnail.')),
                 ('collection', models.ForeignKey(help_text='Show images in this collection in the gallery view.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Collection')),

--- a/wagtail_simple_gallery/migrations/0002_auto_20170309_1046.py
+++ b/wagtail_simple_gallery/migrations/0002_auto_20170309_1046.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.wagtailcore.fields
+import wagtail.core.fields
 
 
 class Migration(migrations.Migration):
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='simplegalleryindex',
             name='intro_text',
-            field=wagtail.wagtailcore.fields.RichTextField(blank=True, help_text='Optional text to go with the intro text.', verbose_name='Intro text'),
+            field=wagtail.core.fields.RichTextField(blank=True, help_text='Optional text to go with the intro text.', verbose_name='Intro text'),
         ),
         migrations.AlterField(
             model_name='simplegalleryindex',

--- a/wagtail_simple_gallery/models.py
+++ b/wagtail_simple_gallery/models.py
@@ -1,14 +1,12 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf import settings
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
-from wagtail.wagtailcore.fields import RichTextField
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailimages.models import Image
+from wagtail.admin.edit_handlers import FieldPanel
+from wagtail.core.fields import RichTextField
+from wagtail.core.models import Page
+from wagtail.images.models import Image
 
 
 IMAGE_ORDER_TYPES = (

--- a/wagtail_simple_gallery/urls.py
+++ b/wagtail_simple_gallery/urls.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import, unicode_literals
-
-from django.conf.urls import url
+from django.urls import path
 
 from .views import index
 
 urlpatterns = [
-    url(r'^admin/images/$', index, name='index'),
+    # FIXME: What if wagtailadmin is located in 'cms/' URL?
+    path('admin/images/', index, name='index'),
 ]

--- a/wagtail_simple_gallery/views.py
+++ b/wagtail_simple_gallery/views.py
@@ -1,17 +1,15 @@
 # wagtail/wagtail/wagtailimages/views/images.py
 # 7d490f7 on 17 Jun
-from __future__ import absolute_import, unicode_literals
-
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.utils.pagination import paginate
-from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import PermissionPolicyChecker, popular_tags_for_model
-from wagtail.wagtailcore.models import Collection
-from wagtail.wagtailimages import get_image_model
-from wagtail.wagtailimages.permissions import permission_policy
+from wagtail.admin.forms import SearchForm
+from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
+from wagtail.core.models import Collection
+from wagtail.images import get_image_model
+from wagtail.images.permissions import permission_policy
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 

--- a/wagtail_simple_gallery/wagtail_hooks.py
+++ b/wagtail_simple_gallery/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.utils.html import format_html
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
-from wagtail.wagtailcore import hooks
+from wagtail.core import hooks
 
 
 @hooks.register('insert_global_admin_css')


### PR DESCRIPTION
Because Django 2.0 drops Python 2 support, we also don't need to support Python 2.