### PR TITLE
Small fix for gallery page image ordering

### DIFF
--- a/wagtail_simple_gallery/models.py
+++ b/wagtail_simple_gallery/models.py
@@ -88,9 +88,9 @@ def get_gallery_images(collection, page=None, tags=None):
     try:
         images = get_image_model().objects.filter(collection__name=collection)
         if page:
-            if page.order_images_by == 0:
+            if page.order_images_by == 1:
                 images = images.order_by('title')
-            elif page.order_images_by == 1:
+            elif page.order_images_by == 2:
                 images = images.order_by('-created_at')
     except Exception as e:
         pass


### PR DESCRIPTION
Fixed small issue with the get_gallery_images conditional using the values 0 and 1, instead of the valid IMAGE_ORDER_TYPES choices, which are 1 and 2.