### PR TITLE
Fix hardcoded default template use in tags route

### DIFF
--- a/wagtail_simple_gallery/models.py
+++ b/wagtail_simple_gallery/models.py
@@ -119,7 +119,7 @@ class SimpleGalleryIndex(RoutablePageMixin, Page):
         context['gallery_images'] = images
         context['gallery_tags'] = tags
         context['current_tag'] = tag
-        return render(request, 'wagtail_simple_gallery/simple_gallery_index.html', context)
+        return render(request, getattr(settings, 'SIMPLE_GALLERY_TEMPLATE', 'wagtail_simple_gallery/simple_gallery_index.html'), context)
 
     class Meta:
         verbose_name = _('Gallery index')


### PR DESCRIPTION
Try to use configured template in tags route return statement but fall back to default if not found.