### PR TITLE
Make page type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Current version works with Wagtail 2.8.x - 2.16.x & Django 2.2.x - 3.2.x.
 ### Use
 - Create a new collection in Wagtail CMS: **Settings -> Collections**.
 - Add or upload images to the collection.
-- Create a new page using the **Simple Gallery Index** template and select the new collection.
+- Create a new page using the **Gallery index** type and select the new collection.
 - You are done, preview or publish the page and you should see the gallery in action.
 
 
@@ -26,10 +26,13 @@ Current version works with Wagtail 2.8.x - 2.16.x & Django 2.2.x - 3.2.x.
 
 ## Settings
 ### `SIMPLE_GALLERY_TEMPLATE`
-You can override the `SimpleGalleryIndex` page template with this setting. Default: `'wagtail_simple_gallery/simple_gallery_index.html'`
+You can override the `SimpleGalleryIndex` page template with this setting. Default: `wagtail_simple_gallery/simple_gallery_index.html`
 
 ### `SIMPLE_GALLERY_ADMIN_URL_ROOT`
 You can use this with the [Admin Interface](#admin-interface) if you use something other than "admin" for accessing the cms admin panel. Default: `admin`
+
+### `SIMPLE_GALLERY_PAGE_TYPE` / `SIMPLE_GALLERY_PAGE_TYPE_PLURAL`
+The page type presented to a Wagtail CMS user can be adjusted with these settings. Defaults: `Gallery index` / `Gallery indices`.
 
 ## Templatetags
 `{% load wagtailsimplegallery_tags %}`

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ You can override the `SimpleGalleryIndex` page template with this setting. Defau
 ### `SIMPLE_GALLERY_ADMIN_URL_ROOT`
 You can use this with the [Admin Interface](#admin-interface) if you use something other than "admin" for accessing the cms admin panel. Default: `admin`
 
-### `SIMPLE_GALLERY_PAGE_TYPE` / `SIMPLE_GALLERY_PAGE_TYPE_PLURAL`
-The page type presented to a Wagtail CMS user can be adjusted with these settings. Defaults: `Gallery index` / `Gallery indices`.
+### `SIMPLE_GALLERY_PAGE_TYPE`
+The page type presented to a Wagtail CMS user can be adjusted with this setting. Default: `Gallery index`.
 
 ## Templatetags
 `{% load wagtailsimplegallery_tags %}`

--- a/wagtail_simple_gallery/models.py
+++ b/wagtail_simple_gallery/models.py
@@ -122,8 +122,8 @@ class SimpleGalleryIndex(RoutablePageMixin, Page):
         return render(request, getattr(settings, 'SIMPLE_GALLERY_TEMPLATE', 'wagtail_simple_gallery/simple_gallery_index.html'), context)
 
     class Meta:
-        verbose_name = _('Gallery index')
-        verbose_name_plural = _('Gallery indices')
+        verbose_name = _(getattr(settings, 'SIMPLE_GALLERY_PAGE_TYPE', 'Gallery index'))
+        verbose_name_plural = _(getattr(settings, 'SIMPLE_GALLERY_PAGE_TYPE_PLURAL', 'Gallery indices'))
 
     template = getattr(settings, 'SIMPLE_GALLERY_TEMPLATE', 'wagtail_simple_gallery/simple_gallery_index.html')
 

--- a/wagtail_simple_gallery/models.py
+++ b/wagtail_simple_gallery/models.py
@@ -123,7 +123,6 @@ class SimpleGalleryIndex(RoutablePageMixin, Page):
 
     class Meta:
         verbose_name = _(getattr(settings, 'SIMPLE_GALLERY_PAGE_TYPE', 'Gallery index'))
-        verbose_name_plural = _(getattr(settings, 'SIMPLE_GALLERY_PAGE_TYPE_PLURAL', 'Gallery indices'))
 
     template = getattr(settings, 'SIMPLE_GALLERY_TEMPLATE', 'wagtail_simple_gallery/simple_gallery_index.html')
 


### PR DESCRIPTION
Fixes: #14 

See the commit message for details on the PR. I kept the original `class Meta:` name of "Gallery index" since I think it could confuse existing wagtail-simple-gallery users if it changes after an upgrade. I adjusted the readme accordingly. What do you think about this decision?

Also I was thinking about the "overhead" of having to configure the _PLURAL name variable as well to keep things consistent: I'm not sure where this would be used and why it's necessary. I'm not a very experienced Django/Wagtail user, maybe you know by heart why this is important to set? Thanks!