### PR TITLE
Compatibility with Wagtail 5.x #22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,36 +2,36 @@ import os
 from setuptools import find_packages, setup
 from wagtail_simple_gallery import __version__
 
-with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    name='wagtail-simple-gallery',
+    name="wagtail-simple-gallery",
     version=__version__,
-    author='Teemu Nieminen',
-    author_email='temeez.dev@gmail.com',
-    description='A simple gallery app for Wagtail.',
+    author="Teemu Nieminen",
+    author_email="temeez.dev@gmail.com",
+    description="A simple gallery app for Wagtail.",
     long_description=README,
-    long_description_content_type='text/markdown',
-    license='MIT License',
-    url='https://github.com/temeez/wagtail-simple-gallery',
-    keywords='wagtail cms model page templatetags',
+    long_description_content_type="text/markdown",
+    license="MIT License",
+    url="https://github.com/temeez/wagtail-simple-gallery",
+    keywords="wagtail cms model page templatetags",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'django>=2.2',
-        'wagtail>=2.5,<5.0',
+        "django>=2.2",
+        "wagtail>=2.5,<6.0",
     ],
     classifiers=[
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Topic :: Internet :: WWW/HTTP',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
 )

--- a/wagtail_simple_gallery/__init__.py
+++ b/wagtail_simple_gallery/__init__.py
@@ -1,2 +1,3 @@
-default_app_config = 'wagtail_simple_gallery.apps.WagtailSimpleGalleryConfig'
-__version__ = '0.9.1'
+default_app_config = "wagtail_simple_gallery.apps.WagtailSimpleGalleryConfig"
+# __version__ = '0.9.1'
+__version__ = "0.9.2a"

--- a/wagtail_simple_gallery/migrations/0001_initial.py
+++ b/wagtail_simple_gallery/migrations/0001_initial.py
@@ -4,31 +4,67 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.core.fields
+
+try:
+    from wagtail.core import fields
+except ImportError:
+    from wagtail import fields
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
-        ('wagtailcore', '0028_merge'),
+        ("wagtailcore", "0028_merge"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='SimpleGalleryIndex',
+            name="SimpleGalleryIndex",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('intro_title', models.CharField(blank=True, help_text='Optional H1 title for the gallery page.', max_length=250)),
-                ('intro_text', wagtail.core.fields.RichTextField(blank=True, help_text='Optional text to go with the intro text.')),
-                ('images_per_page', models.IntegerField(default=8, help_text='How many images there should be on one page.')),
-                ('use_lightbox', models.BooleanField(default=True, help_text='Use lightbox to view larger images when clicking the thumbnail.')),
-                ('collection', models.ForeignKey(help_text='Show images in this collection in the gallery view.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Collection')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "intro_title",
+                    models.CharField(blank=True, help_text="Optional H1 title for the gallery page.", max_length=250),
+                ),
+                (
+                    "intro_text",
+                    fields.RichTextField(blank=True, help_text="Optional text to go with the intro text."),
+                ),
+                (
+                    "images_per_page",
+                    models.IntegerField(default=8, help_text="How many images there should be on one page."),
+                ),
+                (
+                    "use_lightbox",
+                    models.BooleanField(
+                        default=True, help_text="Use lightbox to view larger images when clicking the thumbnail."
+                    ),
+                ),
+                (
+                    "collection",
+                    models.ForeignKey(
+                        help_text="Show images in this collection in the gallery view.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailcore.Collection",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page',),
+            bases=("wagtailcore.page",),
         ),
     ]

--- a/wagtail_simple_gallery/migrations/0002_auto_20170309_1046.py
+++ b/wagtail_simple_gallery/migrations/0002_auto_20170309_1046.py
@@ -4,43 +4,66 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.core.fields
+
+try:
+    from wagtail.core import fields
+except:
+    from wagtail import fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('wagtail_simple_gallery', '0001_initial'),
+        ("wagtail_simple_gallery", "0001_initial"),
     ]
 
     operations = [
         migrations.AlterModelOptions(
-            name='simplegalleryindex',
-            options={'verbose_name': 'Gallery index', 'verbose_name_plural': 'Gallery indices'},
+            name="simplegalleryindex",
+            options={"verbose_name": "Gallery index", "verbose_name_plural": "Gallery indices"},
         ),
         migrations.AlterField(
-            model_name='simplegalleryindex',
-            name='collection',
-            field=models.ForeignKey(help_text='Show images in this collection in the gallery view.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Collection', verbose_name='Collection'),
+            model_name="simplegalleryindex",
+            name="collection",
+            field=models.ForeignKey(
+                help_text="Show images in this collection in the gallery view.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailcore.Collection",
+                verbose_name="Collection",
+            ),
         ),
         migrations.AlterField(
-            model_name='simplegalleryindex',
-            name='images_per_page',
-            field=models.IntegerField(default=8, help_text='How many images there should be on one page.', verbose_name='Images per page'),
+            model_name="simplegalleryindex",
+            name="images_per_page",
+            field=models.IntegerField(
+                default=8, help_text="How many images there should be on one page.", verbose_name="Images per page"
+            ),
         ),
         migrations.AlterField(
-            model_name='simplegalleryindex',
-            name='intro_text',
-            field=wagtail.core.fields.RichTextField(blank=True, help_text='Optional text to go with the intro text.', verbose_name='Intro text'),
+            model_name="simplegalleryindex",
+            name="intro_text",
+            field=fields.RichTextField(
+                blank=True, help_text="Optional text to go with the intro text.", verbose_name="Intro text"
+            ),
         ),
         migrations.AlterField(
-            model_name='simplegalleryindex',
-            name='intro_title',
-            field=models.CharField(blank=True, help_text='Optional H1 title for the gallery page.', max_length=250, verbose_name='Intro title'),
+            model_name="simplegalleryindex",
+            name="intro_title",
+            field=models.CharField(
+                blank=True,
+                help_text="Optional H1 title for the gallery page.",
+                max_length=250,
+                verbose_name="Intro title",
+            ),
         ),
         migrations.AlterField(
-            model_name='simplegalleryindex',
-            name='use_lightbox',
-            field=models.BooleanField(default=True, help_text='Use lightbox to view larger images when clicking the thumbnail.', verbose_name='Use lightbox'),
+            model_name="simplegalleryindex",
+            name="use_lightbox",
+            field=models.BooleanField(
+                default=True,
+                help_text="Use lightbox to view larger images when clicking the thumbnail.",
+                verbose_name="Use lightbox",
+            ),
         ),
     ]

--- a/wagtail_simple_gallery/models.py
+++ b/wagtail_simple_gallery/models.py
@@ -93,7 +93,9 @@ class SimpleGalleryIndex(RoutablePageMixin, Page):
         context["gallery_tags"] = tags
         return context
 
-    def get_gallery_tags(self, tags=[]):
+    def get_gallery_tags(self, tags=None):
+        if tags is None:
+            tags = []
         images = get_gallery_images(self.collection.name, self, tags=tags)
         for img in images:
             tags += img.tags.all()
@@ -103,16 +105,13 @@ class SimpleGalleryIndex(RoutablePageMixin, Page):
     @route("^tags/$", name="tag_archive")
     @route("^tags/([\w-]+)/$", name="tag_archive")
     def tag_archive(self, request, tag=None):
+        taglist = []
         try:
             tag = Tag.objects.get(slug=tag)
         except Tag.DoesNotExist:
             return redirect(self.url)
-        try:
-            taglist.append(tag)
-        except NameError:
-            taglist = []
-            taglist.append(tag)
 
+        taglist.append(tag)
         images = get_gallery_images(self.collection.name, self, tags=taglist)
         tags = self.get_gallery_tags(tags=taglist)
         paginator = Paginator(images, self.images_per_page)

--- a/wagtail_simple_gallery/wagtail_hooks.py
+++ b/wagtail_simple_gallery/wagtail_hooks.py
@@ -1,9 +1,12 @@
 from django.utils.html import format_html
 from django.templatetags.static import static
 
-from wagtail.core import hooks
+try:
+    from wagtail.core import hooks
+except ImportError:
+    from wagtail import hooks
 
 
-@hooks.register('insert_global_admin_css')
+@hooks.register("insert_global_admin_css")
 def global_admin_css():
-    return format_html('<link rel="stylesheet" href="{}">', static('css/simple-gallery-admin.css'))
+    return format_html('<link rel="stylesheet" href="{}">', static("css/simple-gallery-admin.css"))


### PR DESCRIPTION
This PR add compatibility for wagtail 5.x:

+ Change import using try/except for wagtail internal API changes (wagtail.core.fields -> wagtail.field...)
+ Upgrade __version__ to 0.9.2a
+ Upgrade dependencies
+ Fix issue (from linter) about initialized parameter in `wagtail_simple_gallery.models.SimpleGalleryIndex.tag_archive()` method

Thanks !