### PR TITLE
removes original_url filter in favor of wagtail built-in url property

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Uses the template **wagtail_simple_gallery/simple_gallery.html**. You can use th
 - `image_limit` (default: None): Limit the amount of images to show. Example: `{% simple_gallery image_limit=4 %}`.
 - `use_lightbox` (default: True): Use lightbox for viewing images. Example: `{% simple_gallery use_lightbox=False %}`.
 
-### `{% img|original_url %}` filter
-- Takes wagtails Image object and returns its real original url instead of the one that wagtail creates. Example: `/media/original_images/foo.jpg`.
-
-
 ### `{% img.alt|hide_num_order %}` filter
 - Hides the first occurance of `[<number>]` in the image title. E.g "[0010] Cute cat" -> "Cute cat"
 

--- a/wagtail_simple_gallery/templates/wagtail_simple_gallery/simple_gallery.html
+++ b/wagtail_simple_gallery/templates/wagtail_simple_gallery/simple_gallery.html
@@ -4,11 +4,12 @@
   <div class="row gallery-container">
   {% for img in gallery_images %}
     {% image img fill-250x250 as img_thumb %}
+    {% image img original as original_img %}
     <div class="gallery-thumbnail-container col-xs-3">
-      <a href="{{ img|original_url }}" title="{{ img_thumb.alt|hide_num_order }}">
+      <a href="{{ original_img.url }}" title="{{ img_thumb.alt|hide_num_order }}">
         <img src="{{ img_thumb.url }}" alt="{{ img_thumb.alt }}" class="gallery-thumbnail">
       </a>
-      <link rel="preload" href="{{ img|original_url }}">
+      <link rel="preload" href="{{ original_img.url }}">
     </div>
   {% endfor %}
   </div>

--- a/wagtail_simple_gallery/templatetags/wagtailsimplegallery_tags.py
+++ b/wagtail_simple_gallery/templatetags/wagtailsimplegallery_tags.py
@@ -24,11 +24,6 @@ def simple_gallery(collection=None, tags=None, image_limit=None, use_lightbox=Tr
 
 
 @register.filter
-def original_url(image):
-    return os.path.join(settings.MEDIA_URL, str(image.file))
-
-
-@register.filter
 def hide_num_order(title):
     number_match = re.match(r'^.*?\[[^\d]*(\d+)[^\d]*\].*$', title)
     if number_match:


### PR DESCRIPTION
# Problem

The original_url filter that exists in the codebase is not a flexible implementation. 
Specifically, it assumes that the images are in the media folder which is usually not the case in production/live environments.

The STORAGES can be configured as described in the wagtail documentation here: https://docs.wagtail.org/en/stable/advanced_topics/documents/storing_and_serving.html
And Django documentation here:
https://docs.djangoproject.com/en/5.1/ref/settings/#storages

# Solution

This PR removes the filter original_url from the code and the README. 
Instead it adds in the template an original image handler and uses the url property to calculate the hyperlink similar to how the thumbnail is calculated. 
 